### PR TITLE
feat: auto-display Bismillah before surahs and prepend audio on playback

### DIFF
--- a/apps/web/src/components/quran/MushafView.tsx
+++ b/apps/web/src/components/quran/MushafView.tsx
@@ -1,11 +1,16 @@
 import type { Verse } from "@mahfuz/shared/types";
+import { Bismillah } from "./Bismillah";
 import { usePreferencesStore, getActiveColors } from "~/stores/usePreferencesStore";
+
+/** Surahs that do NOT get a Bismillah prefix */
+const NO_BISMILLAH_SURAHS = new Set([1, 9]);
 
 interface MushafViewProps {
   verses: Verse[];
+  showBismillah?: boolean;
 }
 
-export function MushafView({ verses }: MushafViewProps) {
+export function MushafView({ verses, showBismillah = true }: MushafViewProps) {
   const colorizeWords = usePreferencesStore((s) => s.colorizeWords);
   const colorPaletteId = usePreferencesStore((s) => s.colorPaletteId);
   const colors = getActiveColors({ colorPaletteId });
@@ -40,10 +45,22 @@ export function MushafView({ verses }: MushafViewProps) {
                 dir="rtl"
               >
                 {verses.map((verse) => {
+                  const surahId = Number(verse.verse_key.split(":")[0]);
+                  const needsBismillah =
+                    showBismillah &&
+                    verse.verse_number === 1 &&
+                    !NO_BISMILLAH_SURAHS.has(surahId);
                   const words =
                     verse.words?.filter((w) => w.char_type_name === "word") ?? [];
                   return (
                     <span key={verse.id}>
+                      {needsBismillah && (
+                        <>
+                          <span className="block w-full py-2 text-[1.5rem]">
+                            بِسْمِ ٱللَّهِ ٱلرَّحْمَـٰنِ ٱلرَّحِيمِ
+                          </span>
+                        </>
+                      )}
                       {colorizeWords && words.length > 0
                         ? words.map((w, i) => (
                             <span

--- a/apps/web/src/components/quran/VerseList.tsx
+++ b/apps/web/src/components/quran/VerseList.tsx
@@ -1,35 +1,51 @@
 import type { Verse } from "@mahfuz/shared/types";
 import { AyahText } from "./AyahText";
+import { Bismillah } from "./Bismillah";
 import { MushafView } from "./MushafView";
 import { usePreferencesStore } from "~/stores/usePreferencesStore";
+
+/** Surahs that do NOT get a Bismillah prefix (Al-Fatiha has it as verse 1, At-Tawbah has none) */
+const NO_BISMILLAH_SURAHS = new Set([1, 9]);
 
 interface VerseListProps {
   verses: Verse[];
   showTranslation?: boolean;
+  showBismillah?: boolean;
   onPlayFromVerse?: (verseKey: string) => void;
 }
 
 export function VerseList({
   verses,
   showTranslation = true,
+  showBismillah = true,
   onPlayFromVerse,
 }: VerseListProps) {
   const viewMode = usePreferencesStore((s) => s.viewMode);
 
   if (viewMode === "mushaf") {
-    return <MushafView verses={verses} />;
+    return <MushafView verses={verses} showBismillah={showBismillah} />;
   }
 
   return (
     <div className="divide-y divide-[var(--theme-divider)]/40">
-      {verses.map((verse) => (
-        <AyahText
-          key={verse.id}
-          verse={verse}
-          showTranslation={showTranslation}
-          onPlayFromVerse={onPlayFromVerse}
-        />
-      ))}
+      {verses.map((verse) => {
+        const surahId = Number(verse.verse_key.split(":")[0]);
+        const needsBismillah =
+          showBismillah &&
+          verse.verse_number === 1 &&
+          !NO_BISMILLAH_SURAHS.has(surahId);
+
+        return (
+          <div key={verse.id}>
+            {needsBismillah && <Bismillah />}
+            <AyahText
+              verse={verse}
+              showTranslation={showTranslation}
+              onPlayFromVerse={onPlayFromVerse}
+            />
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/apps/web/src/routes/_app/surah/$surahId.tsx
+++ b/apps/web/src/routes/_app/surah/$surahId.tsx
@@ -4,7 +4,7 @@ import { useState, useCallback, useRef, useEffect } from "react";
 import { chapterQueryOptions } from "~/hooks/useChapters";
 import { versesByChapterQueryOptions } from "~/hooks/useVerses";
 import { verseAudioQueryOptions } from "~/hooks/useAudio";
-import { SurahHeader, Bismillah, VerseList, Pagination, ReadingToolbar } from "~/components/quran";
+import { SurahHeader, VerseList, Pagination, ReadingToolbar } from "~/components/quran";
 import { Loading } from "~/components/ui/Loading";
 import { SegmentedControl } from "~/components/ui/SegmentedControl";
 import { TOTAL_CHAPTERS } from "@mahfuz/shared/constants";
@@ -140,17 +140,37 @@ function SurahView() {
     }));
   }, [queryClient, reciterId, chapterId]);
 
+  /** Fetch Bismillah audio (verse 1:1 from Al-Fatiha) to prepend before surahs */
+  const fetchBismillahAudio = useCallback(async (): Promise<VerseAudioData | null> => {
+    if (!chapter.bismillah_pre) return null;
+    const fatihaAudio = await queryClient.fetchQuery(
+      verseAudioQueryOptions(reciterId, 1),
+    );
+    const bismillah = fatihaAudio.find((f) => f.verse_key === "1:1");
+    if (!bismillah) return null;
+    return {
+      verseKey: "bismillah",
+      url: bismillah.url,
+      segments: bismillah.segments,
+    };
+  }, [queryClient, reciterId, chapter.bismillah_pre]);
+
   const handlePlaySurah = useCallback(async () => {
     if (isPlayingThisSurah) {
       togglePlayPause();
       return;
     }
-    const audioData = await fetchAudioData();
-    playSurah(chapterId, chapter.translated_name.name, audioData);
+    const [audioData, bismillah] = await Promise.all([
+      fetchAudioData(),
+      fetchBismillahAudio(),
+    ]);
+    const playlist = bismillah ? [bismillah, ...audioData] : audioData;
+    playSurah(chapterId, chapter.translated_name.name, playlist);
   }, [
     isPlayingThisSurah,
     togglePlayPause,
     fetchAudioData,
+    fetchBismillahAudio,
     playSurah,
     chapterId,
     chapter.translated_name.name,
@@ -158,15 +178,23 @@ function SurahView() {
 
   const handlePlayFromVerse = useCallback(
     async (verseKey: string) => {
-      const audioData = await fetchAudioData();
+      const [audioData, bismillah] = await Promise.all([
+        fetchAudioData(),
+        fetchBismillahAudio(),
+      ]);
+      // Prepend Bismillah when playing from the first verse
+      const isFirstVerse = verseKey === `${chapterId}:1`;
+      const playlist =
+        bismillah && isFirstVerse ? [bismillah, ...audioData] : audioData;
+      const playKey = bismillah && isFirstVerse ? "bismillah" : verseKey;
       playVerse(
         chapterId,
         chapter.translated_name.name,
-        verseKey,
-        audioData,
+        playKey,
+        playlist,
       );
     },
-    [fetchAudioData, playVerse, chapterId, chapter.translated_name.name],
+    [fetchAudioData, fetchBismillahAudio, playVerse, chapterId, chapter.translated_name.name],
   );
 
   const hasPrev = chapterId > 1;
@@ -241,10 +269,7 @@ function SurahView() {
           </button>
         )}
 
-        {/* Bismillah */}
-        {chapter.bismillah_pre && <Bismillah />}
-
-        {/* Verses */}
+        {/* Verses (Bismillah is rendered automatically by VerseList for the first verse of a surah) */}
         <VerseList
           verses={versesData.verses}
           showTranslation={showTranslation}


### PR DESCRIPTION
- VerseList and MushafView now automatically render Bismillah when a surah's first verse appears (except Al-Fatiha and At-Tawbah)
- Surah audio playback prepends the Bismillah recitation (verse 1:1) before the first ayah, using the selected reciter's voice
- Playing from verse 1 also includes Bismillah; mid-surah playback skips it
- Removed duplicate explicit Bismillah rendering from surah view