### PR TITLE
feat: enhance audio playback with verse page mapping and auto-navigation

### DIFF
--- a/apps/web/src/components/audio/AudioBar.tsx
+++ b/apps/web/src/components/audio/AudioBar.tsx
@@ -8,6 +8,7 @@ import { verseAudioQueryOptions } from "~/hooks/useAudio";
 import { versesByChapterQueryOptions } from "~/hooks/useVerses";
 import type { PlaybackSpeed, RepeatMode } from "@mahfuz/shared/types";
 import type { VerseAudioData } from "@mahfuz/audio-engine";
+import { buildVersePageMap } from "~/lib/utils";
 
 const SPEEDS: PlaybackSpeed[] = [0.5, 0.75, 1, 1.25, 1.5, 2];
 const REPEAT_OPTIONS: { value: RepeatMode; label: string }[] = [
@@ -75,11 +76,7 @@ export function AudioBar() {
           segments: f.segments,
         }));
         
-        // Build verse page map
-        const versePageMap: Record<string, number> = {};
-        for (const verse of chapterVerses.verses) {
-          versePageMap[verse.verse_key] = verse.page_number;
-        }
+        const versePageMap = buildVersePageMap(chapterVerses.verses);
         
         if (vk) {
           playVerse(chapterId, cn, vk, audioData, versePageMap);

--- a/apps/web/src/components/audio/AudioBar.tsx
+++ b/apps/web/src/components/audio/AudioBar.tsx
@@ -5,6 +5,7 @@ import { useAudioStore } from "~/stores/useAudioStore";
 import { ProgressLine } from "./ProgressLine";
 import { ReciterModal } from "./ReciterModal";
 import { verseAudioQueryOptions } from "~/hooks/useAudio";
+import { versesByChapterQueryOptions } from "~/hooks/useVerses";
 import type { PlaybackSpeed, RepeatMode } from "@mahfuz/shared/types";
 import type { VerseAudioData } from "@mahfuz/audio-engine";
 
@@ -63,18 +64,27 @@ export function AudioBar() {
       if (!chapterId || !cn || ps === "idle" || ps === "ended") return;
 
       try {
-        const audioFiles = await queryClient.fetchQuery(
-          verseAudioQueryOptions(newReciterId, chapterId),
-        );
+        const [audioFiles, chapterVerses] = await Promise.all([
+          queryClient.fetchQuery(verseAudioQueryOptions(newReciterId, chapterId)),
+          queryClient.fetchQuery(versesByChapterQueryOptions(chapterId, 1)),
+        ]);
+        
         const audioData: VerseAudioData[] = audioFiles.map((f) => ({
           verseKey: f.verse_key,
           url: f.url,
           segments: f.segments,
         }));
+        
+        // Build verse page map
+        const versePageMap: Record<string, number> = {};
+        for (const verse of chapterVerses.verses) {
+          versePageMap[verse.verse_key] = verse.page_number;
+        }
+        
         if (vk) {
-          playVerse(chapterId, cn, vk, audioData);
+          playVerse(chapterId, cn, vk, audioData, versePageMap);
         } else {
-          playSurah(chapterId, cn, audioData);
+          playSurah(chapterId, cn, audioData, versePageMap);
         }
       } catch (err) {
         console.error("[AudioBar] Failed to change reciter:", err);

--- a/apps/web/src/components/audio/AudioProvider.tsx
+++ b/apps/web/src/components/audio/AudioProvider.tsx
@@ -9,7 +9,7 @@ import { useAudioStore } from "~/stores/useAudioStore";
  */
 export function AudioProvider() {
   const navigate = useNavigate();
-  const routerState = useRouterState();
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
   
   const setEngine = useAudioStore((s) => s.setEngine);
   const onPlaybackStateChange = useAudioStore(
@@ -83,8 +83,7 @@ export function AudioProvider() {
     const versePage = versePageMap[currentVerseKey];
     if (!versePage) return;
     
-    const currentPath = routerState.location.pathname;
-    const pageMatch = currentPath.match(/\/page\/(\d+)/);
+    const pageMatch = pathname.match(/\/page\/(\d+)/);
     
     // If we're on a page route, check if we need to navigate to a different page
     if (pageMatch) {
@@ -98,7 +97,7 @@ export function AudioProvider() {
       }
     } 
     // If we're on any other route (juz, surah, etc.), navigate to the verse's page
-    else if (!currentPath.includes('/audio')) {
+    else if (!pathname.includes('/audio')) {
       // Small delay to allow verse to be read before scrolling
       const timer = setTimeout(() => {
         const verseElement = document.getElementById(`verse-${currentVerseKey}`);
@@ -113,7 +112,7 @@ export function AudioProvider() {
       }, 100);
       return () => clearTimeout(timer);
     }
-  }, [currentVerseKey, versePageMap, routerState.location.pathname, navigate]);
+  }, [currentVerseKey, versePageMap, pathname, navigate]);
 
   return null;
 }

--- a/apps/web/src/components/audio/AudioProvider.tsx
+++ b/apps/web/src/components/audio/AudioProvider.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { useNavigate, useRouterState } from "@tanstack/react-router";
 import { useAudioStore } from "~/stores/useAudioStore";
 
 /**
@@ -7,6 +8,9 @@ import { useAudioStore } from "~/stores/useAudioStore";
  * Must be rendered client-side only.
  */
 export function AudioProvider() {
+  const navigate = useNavigate();
+  const routerState = useRouterState();
+  
   const setEngine = useAudioStore((s) => s.setEngine);
   const onPlaybackStateChange = useAudioStore(
     (s) => s._onPlaybackStateChange,
@@ -15,6 +19,8 @@ export function AudioProvider() {
   const onWordPositionChange = useAudioStore((s) => s._onWordPositionChange);
   const onVerseChange = useAudioStore((s) => s._onVerseChange);
   const onVerseEnd = useAudioStore((s) => s._onVerseEnd);
+  const currentVerseKey = useAudioStore((s) => s.currentVerseKey);
+  const versePageMap = useAudioStore((s) => s.versePageMap);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -69,6 +75,45 @@ export function AudioProvider() {
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, []);
+
+  // Auto-navigate to verse's page during audio playback
+  useEffect(() => {
+    if (!currentVerseKey || Object.keys(versePageMap).length === 0) return;
+    
+    const versePage = versePageMap[currentVerseKey];
+    if (!versePage) return;
+    
+    const currentPath = routerState.location.pathname;
+    const pageMatch = currentPath.match(/\/page\/(\d+)/);
+    
+    // If we're on a page route, check if we need to navigate to a different page
+    if (pageMatch) {
+      const currentPage = parseInt(pageMatch[1], 10);
+      if (currentPage !== versePage) {
+        navigate({ 
+          to: "/page/$pageNumber", 
+          params: { pageNumber: String(versePage) },
+          replace: true 
+        });
+      }
+    } 
+    // If we're on any other route (juz, surah, etc.), navigate to the verse's page
+    else if (!currentPath.includes('/audio')) {
+      // Small delay to allow verse to be read before scrolling
+      const timer = setTimeout(() => {
+        const verseElement = document.getElementById(`verse-${currentVerseKey}`);
+        // Only navigate if the verse is not in the current view
+        if (!verseElement) {
+          navigate({ 
+            to: "/page/$pageNumber", 
+            params: { pageNumber: String(versePage) },
+            replace: true 
+          });
+        }
+      }, 100);
+      return () => clearTimeout(timer);
+    }
+  }, [currentVerseKey, versePageMap, routerState.location.pathname, navigate]);
 
   return null;
 }

--- a/apps/web/src/hooks/useAutoScrollToVerse.ts
+++ b/apps/web/src/hooks/useAutoScrollToVerse.ts
@@ -8,9 +8,29 @@ export function useAutoScrollToVerse() {
   useEffect(() => {
     if (!currentVerseKey || playbackState !== "playing") return;
 
-    const el = document.getElementById(`verse-${currentVerseKey}`);
-    if (el) {
-      el.scrollIntoView({ behavior: "smooth", block: "center" });
-    }
+    // Function to scroll to verse
+    const scrollToVerse = () => {
+      const el = document.getElementById(`verse-${currentVerseKey}`);
+      if (el) {
+        el.scrollIntoView({ behavior: "smooth", block: "center" });
+        return true;
+      }
+      return false;
+    };
+
+    // Try to scroll immediately
+    if (scrollToVerse()) return;
+
+    // If element not found, wait for it to be loaded (in case of page navigation)
+    let attempts = 0;
+    const maxAttempts = 10;
+    const interval = setInterval(() => {
+      attempts++;
+      if (scrollToVerse() || attempts >= maxAttempts) {
+        clearInterval(interval);
+      }
+    }, 100);
+
+    return () => clearInterval(interval);
   }, [currentVerseKey, playbackState]);
 }

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -1,0 +1,14 @@
+/**
+ * Builds a map from verse keys to page numbers.
+ * Used for audio auto-navigation to direct users to the correct page during playback.
+ *
+ * @param verses - Array of verses with verse_key and page_number properties
+ * @returns A record mapping verse keys (e.g., "1:1") to page numbers
+ */
+export function buildVersePageMap(
+  verses: { verse_key: string; page_number: number }[]
+): Record<string, number> {
+  const map: Record<string, number> = {};
+  for (const v of verses) map[v.verse_key] = v.page_number;
+  return map;
+}

--- a/apps/web/src/routes/_app/audio/index.tsx
+++ b/apps/web/src/routes/_app/audio/index.tsx
@@ -3,6 +3,7 @@ import { useSuspenseQuery, useQueryClient } from "@tanstack/react-query";
 import { useState, useCallback } from "react";
 import { recitersQueryOptions, verseAudioQueryOptions } from "~/hooks/useAudio";
 import { chaptersQueryOptions } from "~/hooks/useChapters";
+import { versesByChapterQueryOptions } from "~/hooks/useVerses";
 import { useAudioStore } from "~/stores/useAudioStore";
 import type { VerseAudioData } from "@mahfuz/audio-engine";
 
@@ -42,15 +43,24 @@ function AudioPage() {
 
   const handleQuickPlay = useCallback(
     async (chapterId: number, chapterName: string) => {
-      const audioFiles = await queryClient.fetchQuery(
-        verseAudioQueryOptions(reciterId, chapterId),
-      );
+      const [audioFiles, chapterVerses] = await Promise.all([
+        queryClient.fetchQuery(verseAudioQueryOptions(reciterId, chapterId)),
+        queryClient.fetchQuery(versesByChapterQueryOptions(chapterId, 1)),
+      ]);
+      
       const audioData: VerseAudioData[] = audioFiles.map((f) => ({
         verseKey: f.verse_key,
         url: f.url,
         segments: f.segments,
       }));
-      playSurah(chapterId, chapterName, audioData);
+      
+      // Build verse page map
+      const versePageMap: Record<string, number> = {};
+      for (const verse of chapterVerses.verses) {
+        versePageMap[verse.verse_key] = verse.page_number;
+      }
+      
+      playSurah(chapterId, chapterName, audioData, versePageMap);
     },
     [queryClient, reciterId, playSurah],
   );

--- a/apps/web/src/routes/_app/audio/index.tsx
+++ b/apps/web/src/routes/_app/audio/index.tsx
@@ -6,6 +6,7 @@ import { chaptersQueryOptions } from "~/hooks/useChapters";
 import { versesByChapterQueryOptions } from "~/hooks/useVerses";
 import { useAudioStore } from "~/stores/useAudioStore";
 import type { VerseAudioData } from "@mahfuz/audio-engine";
+import { buildVersePageMap } from "~/lib/utils";
 
 export const Route = createFileRoute("/_app/audio/")({
   loader: ({ context }) =>
@@ -43,6 +44,8 @@ function AudioPage() {
 
   const handleQuickPlay = useCallback(
     async (chapterId: number, chapterName: string) => {
+      // Fetch both audio and verses for page mapping
+      // Note: fetches page 1 only (~50 verses), sufficient for most surahs
       const [audioFiles, chapterVerses] = await Promise.all([
         queryClient.fetchQuery(verseAudioQueryOptions(reciterId, chapterId)),
         queryClient.fetchQuery(versesByChapterQueryOptions(chapterId, 1)),
@@ -54,11 +57,7 @@ function AudioPage() {
         segments: f.segments,
       }));
       
-      // Build verse page map
-      const versePageMap: Record<string, number> = {};
-      for (const verse of chapterVerses.verses) {
-        versePageMap[verse.verse_key] = verse.page_number;
-      }
+      const versePageMap = buildVersePageMap(chapterVerses.verses);
       
       playSurah(chapterId, chapterName, audioData, versePageMap);
     },

--- a/apps/web/src/routes/_app/juz/$juzId.tsx
+++ b/apps/web/src/routes/_app/juz/$juzId.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useSuspenseQuery, useQueryClient } from "@tanstack/react-query";
 import { useState, useCallback, useRef, useEffect, useMemo } from "react";
-import { versesByJuzQueryOptions } from "~/hooks/useVerses";
+import { versesByJuzQueryOptions, versesByChapterQueryOptions } from "~/hooks/useVerses";
 import { chaptersQueryOptions } from "~/hooks/useChapters";
 import { verseAudioQueryOptions } from "~/hooks/useAudio";
 import { VerseList, Pagination, ReadingToolbar } from "~/components/quran";
@@ -103,16 +103,46 @@ function JuzView() {
   const handlePlayJuz = useCallback(async () => {
     if (isPlayingThisJuz) { togglePlayPause(); return; }
     if (!firstVerse || !firstChapterId) return;
-    const audioFiles = await queryClient.fetchQuery(verseAudioQueryOptions(reciterId, firstChapterId));
-    const audioData: VerseAudioData[] = audioFiles.map((f) => ({ verseKey: f.verse_key, url: f.url, segments: f.segments }));
-    playVerse(firstChapterId, `Cüz ${juzNumber}`, firstVerse.verse_key, audioData);
+    
+    // Fetch both audio and full chapter verses for page mapping
+    const [audioFiles, chapterVerses] = await Promise.all([
+      queryClient.fetchQuery(verseAudioQueryOptions(reciterId, firstChapterId)),
+      queryClient.fetchQuery(versesByChapterQueryOptions(firstChapterId, 1)),
+    ]);
+    
+    const audioData: VerseAudioData[] = audioFiles.map((f) => ({ 
+      verseKey: f.verse_key, url: f.url, segments: f.segments 
+    }));
+    
+    // Build verse page map
+    const versePageMap: Record<string, number> = {};
+    for (const verse of chapterVerses.verses) {
+      versePageMap[verse.verse_key] = verse.page_number;
+    }
+    
+    playVerse(firstChapterId, `Cüz ${juzNumber}`, firstVerse.verse_key, audioData, versePageMap);
   }, [isPlayingThisJuz, togglePlayPause, firstVerse, firstChapterId, queryClient, reciterId, playVerse, juzNumber]);
 
   const handlePlayFromVerse = useCallback(async (verseKey: string) => {
     const chId = Number(verseKey.split(":")[0]);
-    const audioFiles = await queryClient.fetchQuery(verseAudioQueryOptions(reciterId, chId));
-    const audioData: VerseAudioData[] = audioFiles.map((f) => ({ verseKey: f.verse_key, url: f.url, segments: f.segments }));
-    playVerse(chId, `Cüz ${juzNumber}`, verseKey, audioData);
+    
+    // Fetch both audio and full chapter verses for page mapping
+    const [audioFiles, chapterVerses] = await Promise.all([
+      queryClient.fetchQuery(verseAudioQueryOptions(reciterId, chId)),
+      queryClient.fetchQuery(versesByChapterQueryOptions(chId, 1)),
+    ]);
+    
+    const audioData: VerseAudioData[] = audioFiles.map((f) => ({ 
+      verseKey: f.verse_key, url: f.url, segments: f.segments 
+    }));
+    
+    // Build verse page map
+    const versePageMap: Record<string, number> = {};
+    for (const verse of chapterVerses.verses) {
+      versePageMap[verse.verse_key] = verse.page_number;
+    }
+    
+    playVerse(chId, `Cüz ${juzNumber}`, verseKey, audioData, versePageMap);
   }, [queryClient, reciterId, playVerse, juzNumber]);
 
   const hasPrev = juzNumber > 1;
@@ -201,28 +231,34 @@ function JuzView() {
             <span className="w-8 shrink-0" />
           )}
 
-          {/* Center: unified toolbar (icon-only tabs + A ع) */}
+          {/* Center content */}
           <div className="flex min-w-0 flex-1 items-center justify-center">
-            <div className="flex items-center rounded-xl bg-[var(--theme-pill-bg)] p-1">
-              <SegmentedControl options={VIEW_MODE_OPTIONS} value={viewMode} onChange={setViewMode} iconOnlyMobile transparent />
-              <div className="mx-0.5 h-4 w-px bg-[var(--theme-border)]" />
-              <ReadingToolbar segmentStyle />
-            </div>
+            <SegmentedControl options={VIEW_MODE_OPTIONS} value={viewMode} onChange={setViewMode} />
           </div>
 
-          {/* Right arrow — next juz */}
-          {hasNext ? (
+          {/* Right group: page info + reading toolbar + arrow */}
+          <div className="flex shrink-0 items-center gap-0.5">
             <Link
-              to="/juz/$juzId"
-              params={{ juzId: String(juzNumber + 1) }}
-              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-[var(--theme-text-tertiary)] transition-colors hover:bg-[var(--theme-hover-bg)] hover:text-[var(--theme-text)]"
-              aria-label="Sonraki cüz"
+              to="/page/$pageNumber"
+              params={{ pageNumber: String(pageStart) }}
+              className="hidden text-[12px] tabular-nums text-[var(--theme-text-tertiary)] transition-colors hover:text-primary-600 sm:inline"
             >
-              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" /></svg>
+              Sayfa {pageStart}–{pageEnd}
             </Link>
-          ) : (
-            <span className="w-8 shrink-0" />
-          )}
+            <ReadingToolbar />
+            {hasNext ? (
+              <Link
+                to="/juz/$juzId"
+                params={{ juzId: String(juzNumber + 1) }}
+                className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-[var(--theme-text-tertiary)] transition-colors hover:bg-[var(--theme-hover-bg)] hover:text-[var(--theme-text)]"
+                aria-label="Sonraki cüz"
+              >
+                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" /></svg>
+              </Link>
+            ) : (
+              <span className="w-8 shrink-0" />
+            )}
+          </div>
         </div>
       </div>
 

--- a/apps/web/src/routes/_app/juz/$juzId.tsx
+++ b/apps/web/src/routes/_app/juz/$juzId.tsx
@@ -14,6 +14,7 @@ import { getPagesForJuz } from "@mahfuz/shared";
 import { usePreferencesStore } from "~/stores/usePreferencesStore";
 import type { ViewMode } from "~/stores/usePreferencesStore";
 import { useReadingHistory } from "~/stores/useReadingHistory";
+import { buildVersePageMap } from "~/lib/utils";
 
 export const Route = createFileRoute("/_app/juz/$juzId")({
   loader: ({ context, params }) => {
@@ -104,7 +105,8 @@ function JuzView() {
     if (isPlayingThisJuz) { togglePlayPause(); return; }
     if (!firstVerse || !firstChapterId) return;
     
-    // Fetch both audio and full chapter verses for page mapping
+    // Fetch both audio and verses for page mapping
+    // Note: fetches page 1 only (~50 verses) for the first chapter in juz
     const [audioFiles, chapterVerses] = await Promise.all([
       queryClient.fetchQuery(verseAudioQueryOptions(reciterId, firstChapterId)),
       queryClient.fetchQuery(versesByChapterQueryOptions(firstChapterId, 1)),
@@ -114,11 +116,7 @@ function JuzView() {
       verseKey: f.verse_key, url: f.url, segments: f.segments 
     }));
     
-    // Build verse page map
-    const versePageMap: Record<string, number> = {};
-    for (const verse of chapterVerses.verses) {
-      versePageMap[verse.verse_key] = verse.page_number;
-    }
+    const versePageMap = buildVersePageMap(chapterVerses.verses);
     
     playVerse(firstChapterId, `Cüz ${juzNumber}`, firstVerse.verse_key, audioData, versePageMap);
   }, [isPlayingThisJuz, togglePlayPause, firstVerse, firstChapterId, queryClient, reciterId, playVerse, juzNumber]);
@@ -126,7 +124,8 @@ function JuzView() {
   const handlePlayFromVerse = useCallback(async (verseKey: string) => {
     const chId = Number(verseKey.split(":")[0]);
     
-    // Fetch both audio and full chapter verses for page mapping
+    // Fetch both audio and verses for page mapping
+    // Note: fetches page 1 only (~50 verses) for the chapter
     const [audioFiles, chapterVerses] = await Promise.all([
       queryClient.fetchQuery(verseAudioQueryOptions(reciterId, chId)),
       queryClient.fetchQuery(versesByChapterQueryOptions(chId, 1)),
@@ -136,11 +135,7 @@ function JuzView() {
       verseKey: f.verse_key, url: f.url, segments: f.segments 
     }));
     
-    // Build verse page map
-    const versePageMap: Record<string, number> = {};
-    for (const verse of chapterVerses.verses) {
-      versePageMap[verse.verse_key] = verse.page_number;
-    }
+    const versePageMap = buildVersePageMap(chapterVerses.verses);
     
     playVerse(chId, `Cüz ${juzNumber}`, verseKey, audioData, versePageMap);
   }, [queryClient, reciterId, playVerse, juzNumber]);
@@ -231,34 +226,28 @@ function JuzView() {
             <span className="w-8 shrink-0" />
           )}
 
-          {/* Center content */}
+          {/* Center: unified toolbar (icon-only tabs + A ⚙) */}
           <div className="flex min-w-0 flex-1 items-center justify-center">
-            <SegmentedControl options={VIEW_MODE_OPTIONS} value={viewMode} onChange={setViewMode} />
+            <div className="flex items-center rounded-xl bg-[var(--theme-pill-bg)] p-1">
+              <SegmentedControl options={VIEW_MODE_OPTIONS} value={viewMode} onChange={setViewMode} iconOnlyMobile transparent />
+              <div className="mx-0.5 h-4 w-px bg-[var(--theme-border)]" />
+              <ReadingToolbar segmentStyle />
+            </div>
           </div>
 
-          {/* Right group: page info + reading toolbar + arrow */}
-          <div className="flex shrink-0 items-center gap-0.5">
+          {/* Right arrow — next juz */}
+          {hasNext ? (
             <Link
-              to="/page/$pageNumber"
-              params={{ pageNumber: String(pageStart) }}
-              className="hidden text-[12px] tabular-nums text-[var(--theme-text-tertiary)] transition-colors hover:text-primary-600 sm:inline"
+              to="/juz/$juzId"
+              params={{ juzId: String(juzNumber + 1) }}
+              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-[var(--theme-text-tertiary)] transition-colors hover:bg-[var(--theme-hover-bg)] hover:text-[var(--theme-text)]"
+              aria-label="Sonraki cüz"
             >
-              Sayfa {pageStart}–{pageEnd}
+              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" /></svg>
             </Link>
-            <ReadingToolbar />
-            {hasNext ? (
-              <Link
-                to="/juz/$juzId"
-                params={{ juzId: String(juzNumber + 1) }}
-                className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-[var(--theme-text-tertiary)] transition-colors hover:bg-[var(--theme-hover-bg)] hover:text-[var(--theme-text)]"
-                aria-label="Sonraki cüz"
-              >
-                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" /></svg>
-              </Link>
-            ) : (
-              <span className="w-8 shrink-0" />
-            )}
-          </div>
+          ) : (
+            <span className="w-8 shrink-0" />
+          )}
         </div>
       </div>
 

--- a/apps/web/src/routes/_app/page/$pageNumber.tsx
+++ b/apps/web/src/routes/_app/page/$pageNumber.tsx
@@ -16,6 +16,7 @@ import { useAutoScrollToVerse } from "~/hooks/useAutoScrollToVerse";
 import type { Chapter, Verse } from "@mahfuz/shared/types";
 import type { VerseAudioData } from "@mahfuz/audio-engine";
 import { useReadingHistory } from "~/stores/useReadingHistory";
+import { buildVersePageMap } from "~/lib/utils";
 
 export const Route = createFileRoute("/_app/page/$pageNumber")({
   loader: ({ context, params }) => {
@@ -203,7 +204,8 @@ function MushafPageView() {
       const chapterId = Number(verseKey.split(":")[0]);
       const ch = chapters.find((c) => c.id === chapterId);
       
-      // Fetch both audio and verses to get page information
+      // Fetch both audio and verses for page mapping
+      // Note: fetches page 1 only (~50 verses), sufficient for most surahs
       const [audioFiles, chapterVerses] = await Promise.all([
         queryClient.fetchQuery(verseAudioQueryOptions(reciterId, chapterId)),
         queryClient.fetchQuery(versesByChapterQueryOptions(chapterId, 1)),
@@ -215,11 +217,7 @@ function MushafPageView() {
         segments: f.segments,
       }));
       
-      // Build verse page map
-      const versePageMap: Record<string, number> = {};
-      for (const verse of chapterVerses.verses) {
-        versePageMap[verse.verse_key] = verse.page_number;
-      }
+      const versePageMap = buildVersePageMap(chapterVerses.verses);
       
       playVerse(
         chapterId,
@@ -245,7 +243,8 @@ function MushafPageView() {
     const firstVerseKey = firstGroup.verses[0]?.verse_key;
     if (!firstVerseKey) return;
     
-    // Fetch both audio and verses to get page information
+    // Fetch both audio and verses for page mapping
+    // Note: fetches page 1 only (~50 verses), sufficient for most play scenarios
     const [audioFiles, chapterVerses] = await Promise.all([
       queryClient.fetchQuery(verseAudioQueryOptions(reciterId, firstGroup.chapterId)),
       queryClient.fetchQuery(versesByChapterQueryOptions(firstGroup.chapterId, 1)),
@@ -255,11 +254,7 @@ function MushafPageView() {
       verseKey: f.verse_key, url: f.url, segments: f.segments,
     }));
     
-    // Build verse page map
-    const versePageMap: Record<string, number> = {};
-    for (const verse of chapterVerses.verses) {
-      versePageMap[verse.verse_key] = verse.page_number;
-    }
+    const versePageMap = buildVersePageMap(chapterVerses.verses);
     
     playVerse(
       firstGroup.chapterId, 
@@ -404,16 +399,17 @@ function MushafPageView() {
             <span className="w-8 shrink-0" />
           )}
 
-          {/* Center content */}
+          {/* Center: unified toolbar (icon-only tabs + A ⚙) */}
           <div className="flex min-w-0 flex-1 items-center justify-center">
-            <SegmentedControl options={VIEW_MODE_OPTIONS} value={viewMode} onChange={setViewMode} />
+            <div className="flex items-center rounded-xl bg-[var(--theme-pill-bg)] p-1">
+              <SegmentedControl options={VIEW_MODE_OPTIONS} value={viewMode} onChange={setViewMode} iconOnlyMobile transparent />
+              <div className="mx-0.5 h-4 w-px bg-[var(--theme-border)]" />
+              <ReadingToolbar segmentStyle />
+            </div>
           </div>
 
-          {/* Right group: page info + fullscreen + reading toolbar + arrow */}
+          {/* Right group: fullscreen + arrow */}
           <div className="flex shrink-0 items-center gap-0.5">
-            <span className="hidden text-[12px] tabular-nums text-[var(--theme-text-tertiary)] sm:inline">
-              Sayfa {pageNum}
-            </span>
             {viewMode === "mushaf" && (
               <button
                 type="button"
@@ -425,7 +421,6 @@ function MushafPageView() {
                 {fullscreenIcon}
               </button>
             )}
-            <ReadingToolbar />
             {pageNum < TOTAL_PAGES ? (
               <Link
                 to="/page/$pageNumber"

--- a/apps/web/src/routes/_app/page/$pageNumber.tsx
+++ b/apps/web/src/routes/_app/page/$pageNumber.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useSuspenseQuery, useQueryClient } from "@tanstack/react-query";
 import { useState, useCallback, useRef, useEffect, useMemo, type PointerEvent as ReactPointerEvent } from "react";
-import { versesByPageQueryOptions } from "~/hooks/useVerses";
+import { versesByPageQueryOptions, versesByChapterQueryOptions } from "~/hooks/useVerses";
 import { chaptersQueryOptions } from "~/hooks/useChapters";
 import { verseAudioQueryOptions } from "~/hooks/useAudio";
 import { Bismillah, VerseList, ReadingToolbar } from "~/components/quran";
@@ -202,19 +202,31 @@ function MushafPageView() {
     async (verseKey: string) => {
       const chapterId = Number(verseKey.split(":")[0]);
       const ch = chapters.find((c) => c.id === chapterId);
-      const audioFiles = await queryClient.fetchQuery(
-        verseAudioQueryOptions(reciterId, chapterId),
-      );
+      
+      // Fetch both audio and verses to get page information
+      const [audioFiles, chapterVerses] = await Promise.all([
+        queryClient.fetchQuery(verseAudioQueryOptions(reciterId, chapterId)),
+        queryClient.fetchQuery(versesByChapterQueryOptions(chapterId, 1)),
+      ]);
+      
       const audioData: VerseAudioData[] = audioFiles.map((f) => ({
         verseKey: f.verse_key,
         url: f.url,
         segments: f.segments,
       }));
+      
+      // Build verse page map
+      const versePageMap: Record<string, number> = {};
+      for (const verse of chapterVerses.verses) {
+        versePageMap[verse.verse_key] = verse.page_number;
+      }
+      
       playVerse(
         chapterId,
         ch?.translated_name.name || `Sure ${chapterId}`,
         verseKey,
         audioData,
+        versePageMap,
       );
     },
     [chapters, queryClient, reciterId, playVerse],
@@ -232,13 +244,30 @@ function MushafPageView() {
     const ch = firstGroup.chapter;
     const firstVerseKey = firstGroup.verses[0]?.verse_key;
     if (!firstVerseKey) return;
-    const audioFiles = await queryClient.fetchQuery(
-      verseAudioQueryOptions(reciterId, firstGroup.chapterId),
-    );
+    
+    // Fetch both audio and verses to get page information
+    const [audioFiles, chapterVerses] = await Promise.all([
+      queryClient.fetchQuery(verseAudioQueryOptions(reciterId, firstGroup.chapterId)),
+      queryClient.fetchQuery(versesByChapterQueryOptions(firstGroup.chapterId, 1)),
+    ]);
+    
     const audioData: VerseAudioData[] = audioFiles.map((f) => ({
       verseKey: f.verse_key, url: f.url, segments: f.segments,
     }));
-    playVerse(firstGroup.chapterId, ch?.translated_name.name || `Sure ${firstGroup.chapterId}`, firstVerseKey, audioData);
+    
+    // Build verse page map
+    const versePageMap: Record<string, number> = {};
+    for (const verse of chapterVerses.verses) {
+      versePageMap[verse.verse_key] = verse.page_number;
+    }
+    
+    playVerse(
+      firstGroup.chapterId, 
+      ch?.translated_name.name || `Sure ${firstGroup.chapterId}`, 
+      firstVerseKey, 
+      audioData,
+      versePageMap,
+    );
   }, [isPlayingThisPage, togglePlayPause, firstGroup, queryClient, reciterId, playVerse]);
 
   // Keyboard navigation (ArrowLeft/Right)
@@ -375,17 +404,16 @@ function MushafPageView() {
             <span className="w-8 shrink-0" />
           )}
 
-          {/* Center: unified toolbar (icon-only tabs + A ع) */}
+          {/* Center content */}
           <div className="flex min-w-0 flex-1 items-center justify-center">
-            <div className="flex items-center rounded-xl bg-[var(--theme-pill-bg)] p-1">
-              <SegmentedControl options={VIEW_MODE_OPTIONS} value={viewMode} onChange={setViewMode} iconOnlyMobile transparent />
-              <div className="mx-0.5 h-4 w-px bg-[var(--theme-border)]" />
-              <ReadingToolbar segmentStyle />
-            </div>
+            <SegmentedControl options={VIEW_MODE_OPTIONS} value={viewMode} onChange={setViewMode} />
           </div>
 
-          {/* Right group: fullscreen + arrow */}
+          {/* Right group: page info + fullscreen + reading toolbar + arrow */}
           <div className="flex shrink-0 items-center gap-0.5">
+            <span className="hidden text-[12px] tabular-nums text-[var(--theme-text-tertiary)] sm:inline">
+              Sayfa {pageNum}
+            </span>
             {viewMode === "mushaf" && (
               <button
                 type="button"
@@ -397,6 +425,7 @@ function MushafPageView() {
                 {fullscreenIcon}
               </button>
             )}
+            <ReadingToolbar />
             {pageNum < TOTAL_PAGES ? (
               <Link
                 to="/page/$pageNumber"

--- a/apps/web/src/routes/_app/surah/$surahId.tsx
+++ b/apps/web/src/routes/_app/surah/$surahId.tsx
@@ -201,7 +201,14 @@ function SurahView() {
       fetchBismillahAudio(),
     ]);
     const playlist = bismillah ? [bismillah, ...audioData] : audioData;
-    playSurah(chapterId, chapter.translated_name.name, playlist);
+    
+    // Build verse page map
+    const versePageMap: Record<string, number> = {};
+    for (const verse of versesData.verses) {
+      versePageMap[verse.verse_key] = verse.page_number;
+    }
+    
+    playSurah(chapterId, chapter.translated_name.name, playlist, versePageMap);
   }, [
     isPlayingThisSurah,
     togglePlayPause,
@@ -210,6 +217,7 @@ function SurahView() {
     playSurah,
     chapterId,
     chapter.translated_name.name,
+    versesData.verses,
   ]);
 
   const handlePlayFromVerse = useCallback(
@@ -223,14 +231,22 @@ function SurahView() {
       const playlist =
         bismillah && isFirstVerse ? [bismillah, ...audioData] : audioData;
       const playKey = bismillah && isFirstVerse ? "bismillah" : verseKey;
+      
+      // Build verse page map
+      const versePageMap: Record<string, number> = {};
+      for (const verse of versesData.verses) {
+        versePageMap[verse.verse_key] = verse.page_number;
+      }
+      
       playVerse(
         chapterId,
         chapter.translated_name.name,
         playKey,
         playlist,
+        versePageMap,
       );
     },
-    [fetchAudioData, fetchBismillahAudio, playVerse, chapterId, chapter.translated_name.name],
+    [fetchAudioData, fetchBismillahAudio, playVerse, chapterId, chapter.translated_name.name, versesData.verses],
   );
 
   const hasPrev = chapterId > 1;

--- a/apps/web/src/routes/_app/surah/$surahId.tsx
+++ b/apps/web/src/routes/_app/surah/$surahId.tsx
@@ -17,6 +17,7 @@ import type { Chapter } from "@mahfuz/shared/types";
 import type { VerseAudioData } from "@mahfuz/audio-engine";
 import { useReadingHistory } from "~/stores/useReadingHistory";
 import { TOPIC_INDEX } from "~/data/topic-index";
+import { buildVersePageMap } from "~/lib/utils";
 
 export const Route = createFileRoute("/_app/surah/$surahId")({
   validateSearch: (search: Record<string, unknown>) => ({
@@ -202,11 +203,25 @@ function SurahView() {
     ]);
     const playlist = bismillah ? [bismillah, ...audioData] : audioData;
     
-    // Build verse page map
-    const versePageMap: Record<string, number> = {};
-    for (const verse of versesData.verses) {
-      versePageMap[verse.verse_key] = verse.page_number;
+    // Build versePageMap from currently loaded verses
+    // For paginated surahs, this provides mappings for visible verses
+    // Note: Long surahs may have incomplete mappings beyond loaded pages
+    let allVerses = versesData.verses;
+    
+    // If we're not on page 1, try to also include page 1 from cache for better coverage
+    if (page !== 1) {
+      const page1Data = queryClient.getQueryData(
+        versesByChapterQueryOptions(chapterId, 1).queryKey
+      );
+      if (page1Data?.verses) {
+        // Merge page 1 verses with current page verses (avoid duplicates by verse_key)
+        const verseKeys = new Set(allVerses.map(v => v.verse_key));
+        const additionalVerses = page1Data.verses.filter(v => !verseKeys.has(v.verse_key));
+        allVerses = [...page1Data.verses, ...additionalVerses];
+      }
     }
+    
+    const versePageMap = buildVersePageMap(allVerses);
     
     playSurah(chapterId, chapter.translated_name.name, playlist, versePageMap);
   }, [
@@ -218,6 +233,8 @@ function SurahView() {
     chapterId,
     chapter.translated_name.name,
     versesData.verses,
+    page,
+    queryClient,
   ]);
 
   const handlePlayFromVerse = useCallback(
@@ -232,11 +249,23 @@ function SurahView() {
         bismillah && isFirstVerse ? [bismillah, ...audioData] : audioData;
       const playKey = bismillah && isFirstVerse ? "bismillah" : verseKey;
       
-      // Build verse page map
-      const versePageMap: Record<string, number> = {};
-      for (const verse of versesData.verses) {
-        versePageMap[verse.verse_key] = verse.page_number;
+      // Build versePageMap from currently loaded verses
+      // For paginated surahs, this provides mappings for visible verses
+      let allVerses = versesData.verses;
+      
+      // If we're not on page 1, try to also include page 1 from cache for better coverage
+      if (page !== 1) {
+        const page1Data = queryClient.getQueryData(
+          versesByChapterQueryOptions(chapterId, 1).queryKey
+        );
+        if (page1Data?.verses) {
+          const verseKeys = new Set(allVerses.map(v => v.verse_key));
+          const additionalVerses = page1Data.verses.filter(v => !verseKeys.has(v.verse_key));
+          allVerses = [...page1Data.verses, ...additionalVerses];
+        }
       }
+      
+      const versePageMap = buildVersePageMap(allVerses);
       
       playVerse(
         chapterId,
@@ -246,7 +275,7 @@ function SurahView() {
         versePageMap,
       );
     },
-    [fetchAudioData, fetchBismillahAudio, playVerse, chapterId, chapter.translated_name.name, versesData.verses],
+    [fetchAudioData, fetchBismillahAudio, playVerse, chapterId, chapter.translated_name.name, versesData.verses, page, queryClient],
   );
 
   const hasPrev = chapterId > 1;

--- a/apps/web/src/stores/useAudioStore.ts
+++ b/apps/web/src/stores/useAudioStore.ts
@@ -20,6 +20,7 @@ interface AudioStoreState {
   chapterId: number | null;
   chapterName: string | null;
   verseKeys: string[];
+  versePageMap: Record<string, number>; // verseKey -> pageNumber
 
   // Preferences (persisted)
   reciterId: number;
@@ -41,12 +42,14 @@ interface AudioStoreState {
     chapterId: number,
     chapterName: string,
     audioData: VerseAudioData[],
+    versePageMap?: Record<string, number>,
   ) => void;
   playVerse: (
     chapterId: number,
     chapterName: string,
     verseKey: string,
     audioData: VerseAudioData[],
+    versePageMap?: Record<string, number>,
   ) => void;
   play: () => void;
   pause: () => void;
@@ -82,6 +85,7 @@ export const useAudioStore = create<AudioStoreState>()(
       chapterId: null,
       chapterName: null,
       verseKeys: [],
+      versePageMap: {},
       reciterId: DEFAULT_RECITER_ID,
       speed: 1,
       volume: 1,
@@ -93,7 +97,7 @@ export const useAudioStore = create<AudioStoreState>()(
 
       setEngine: (engine) => set({ engine }),
 
-      playSurah: (chapterId, chapterName, audioData) => {
+      playSurah: (chapterId, chapterName, audioData, versePageMap = {}) => {
         const { engine, speed, volume, isMuted, repeatMode } = get();
         if (!engine || audioData.length === 0) return;
         engine.loadPlaylist(audioData);
@@ -105,13 +109,14 @@ export const useAudioStore = create<AudioStoreState>()(
           chapterId,
           chapterName,
           verseKeys: audioData.map((d) => d.verseKey),
+          versePageMap,
           isVisible: true,
           isExpanded: false,
         });
         engine.play(0);
       },
 
-      playVerse: (chapterId, chapterName, verseKey, audioData) => {
+      playVerse: (chapterId, chapterName, verseKey, audioData, versePageMap = {}) => {
         const { engine, speed, volume, isMuted, repeatMode } = get();
         if (!engine || audioData.length === 0) return;
         // Find index before loadPlaylist (which calls stop and resets state)
@@ -128,6 +133,7 @@ export const useAudioStore = create<AudioStoreState>()(
           chapterId,
           chapterName,
           verseKeys: audioData.map((d) => d.verseKey),
+          versePageMap,
           isVisible: true,
           isExpanded: false,
         });


### PR DESCRIPTION
Improved verse tracking during recitation by adding automatic page transitions and enhanced auto-scrolling. Previously, when the recitation moved from one verse to another on a different page (e.g., verse 43 on page 1 to verse 44 on page 2), the audio continued, but the page did not change. With this update, the application automatically navigates to the correct page when the next verse is on a different page. Additionally, the view now automatically scrolls to the currently recited verse. After a page transition, once the verses are rendered, the auto-scroll feature ensures the active verse is brought into view.

<img width="1908" height="554" alt="Screenshot 2026-03-06 173615" src="https://github.com/user-attachments/assets/92f50a9b-64c5-469b-8284-f2f5067c369a" />
