### PR TITLE
feat(reader): make surah reader topbar sticky on scroll

### DIFF
--- a/apps/web/src/components/reader/SurahView.tsx
+++ b/apps/web/src/components/reader/SurahView.tsx
@@ -205,9 +205,8 @@ export function SurahView({ surahId, highlightAyah }: SurahViewProps) {
 
   return (
     <>
-      <div className="mu-reader" style={{ "--arabic-size": `${arabicFontSize}rem` } as React.CSSProperties}>
-        {/* Top bar */}
-        <div className="mu-reader-topbar" style={{ flexDirection: "column", gap: 0, padding: "12px 0 0", borderBottom: "none", marginBottom: 24 }}>
+      {/* Top bar - outside grid for sticky */}
+      <div className="mu-reader-topbar" style={{ flexDirection: "column", gap: 0, padding: "12px 0 0", borderBottom: "none" }}>
           <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", width: "100%", padding: "0 0 10px" }}>
             {/* Left: back */}
             <Link to="/" className="mu-icon-btn sm" aria-label={t.reader.index} style={{ color: "var(--mu-ink-3)" }}>
@@ -296,6 +295,7 @@ export function SurahView({ surahId, highlightAyah }: SurahViewProps) {
             <div style={{ width: `${progressPct}%`, height: "100%", background: "var(--mu-accent)", borderRadius: 1, transition: "width 0.3s ease" }} />
           </div>
         </div>
+      <div className="mu-reader" style={{ "--arabic-size": `${arabicFontSize}rem` } as React.CSSProperties}>
         {/* Main content */}
         <div>
           {/* Chapter header */}

--- a/apps/web/src/styles/minimal-ui.css
+++ b/apps/web/src/styles/minimal-ui.css
@@ -859,13 +859,19 @@
 }
 
 .mu-reader-topbar {
-  grid-column: 1 / -1;
+  position: sticky;
+  top: 69px;
+  z-index: 30;
+  background: var(--mu-bg);
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 20px 0;
+  padding: 20px 32px;
   border-bottom: 1px solid var(--mu-line);
-  margin-bottom: 32px;
+  max-width: 1320px;
+  margin: 0 auto;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .mu-topbar-play {
@@ -1143,10 +1149,10 @@
 /* Reader side panel */
 .mu-rside {
   position: sticky;
-  top: 96px;
+  top: 140px;
   align-self: start;
   height: fit-content;
-  max-height: calc(100vh - 120px);
+  max-height: calc(100vh - 150px);
   overflow-y: auto;
   overflow-x: hidden;
   padding: 8px 0 40px;
@@ -2883,6 +2889,11 @@
     gap: 0;
   }
 
+  .mu-reader-topbar {
+    padding-left: 20px;
+    padding-right: 20px;
+  }
+
   .mu-rside {
     display: none;
   }
@@ -2926,6 +2937,7 @@
   .mu-mobile-search-btn { display: inline-grid; }
   .mu-topbar-inner { padding: 8px 12px; gap: 8px; }
   .mu-topright { margin-left: auto; }
+  .mu-reader-topbar { padding-left: 12px; padding-right: 12px; top: 89px; }
 }
 
 /* ── Subtle paper texture (light themes only) ──────── */


### PR DESCRIPTION
## Summary
- Move the reader topbar outside the CSS grid container so `position: sticky` works
- Topbar now stays pinned below the main header when scrolling through a surah
- Adjust right sidebar `top` offset to prevent overlap with the sticky topbar
- Responsive padding adjustments for mobile viewports

## Test plan
- [ ] Open a long surah (e.g. /surah/al-baqarah) and scroll down
- [ ] Verify topbar stays pinned below the main header
- [ ] Verify right sidebar (TOC) does not overlap with the topbar
- [ ] Test on mobile viewport widths