### PR TITLE
Fix: validate mushaf page number and guard against null data

### DIFF
--- a/apps/web/src/routes/page/$pageNumber.tsx
+++ b/apps/web/src/routes/page/$pageNumber.tsx
@@ -5,7 +5,7 @@
  * Yatay swipe (+ web'de mouse drag) ile sayfa gecisi (RTL).
  */
 
-import { createFileRoute, useRouter, Link } from "@tanstack/react-router";
+import { createFileRoute, useRouter, Link, notFound } from "@tanstack/react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useCallback, useRef, useState } from "react";
 import { MushafPage } from "~/components/reader/MushafPage";
@@ -25,9 +25,16 @@ export const Route = createFileRoute("/page/$pageNumber")({
   validateSearch: (search: Record<string, unknown>) => ({
     ayah: (search.ayah as string) || undefined,
   }),
-  loader: ({ params, context }) => {
+  loader: async ({ params, context }) => {
     const pageNumber = parseInt(params.pageNumber, 10);
-    return context.queryClient.ensureQueryData(pageDataQueryOptions(pageNumber));
+    if (isNaN(pageNumber) || pageNumber < 1 || pageNumber > TOTAL_PAGES) {
+      throw notFound();
+    }
+    const data = await context.queryClient.ensureQueryData(pageDataQueryOptions(pageNumber));
+    if (!data) {
+      throw notFound();
+    }
+    return data;
   },
   component: PageRoute,
   errorComponent: RouteErrorFallback,


### PR DESCRIPTION
## Summary
- Validate page number (1-604) in route loader, throw `notFound()` for invalid values
- Guard against `getPageData` returning null (empty DB / missing data), throw `notFound()` instead of letting TanStack Start crash with `Cannot read properties of undefined (reading 'payload')`

## Test plan
- [ ] Navigate to `/page/1`, `/page/604` - should work normally
- [ ] Navigate to `/page/0`, `/page/605`, `/page/abc` - should show not found
- [ ] Deploy and verify mushaf view loads without errors