### PR TITLE
feat: redesign profile page and game surah picker with studied surahs

### DIFF
--- a/apps/web/src/components/GameOverCard.tsx
+++ b/apps/web/src/components/GameOverCard.tsx
@@ -32,7 +32,7 @@ export function GameOverCard({
 
   return (
     <div
-      className="max-w-md mx-auto px-4 pt-8 pb-28 text-center game-bounce-in min-h-dvh flex flex-col items-center justify-center game-bg"
+      className="max-w-3xl mx-auto px-4 pt-8 pb-20 text-center game-bounce-in min-h-dvh flex flex-col items-center justify-center game-bg"
       style={gameBgStyle(theme)}
     >
       {/* Trophy circle */}

--- a/apps/web/src/components/SurahPickerScreen.tsx
+++ b/apps/web/src/components/SurahPickerScreen.tsx
@@ -6,14 +6,16 @@
 import { useState } from "react";
 
 import { useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
 import { getSurahs } from "~/lib/quran-service";
 import { useSurahSelectionStore } from "~/stores/surahSelection.store";
 import { useHifzStore } from "~/stores/hifz.store";
+import { useStudiedStore } from "~/stores/studied.store";
 import { useTranslation } from "~/hooks/useTranslation";
 import type { VerseFilter } from "~/lib/game-service";
 import type { Difficulty } from "~/lib/game-scoring";
 
-type Mode = "all" | "hifz" | "custom";
+type Mode = "all" | "hifz" | "studied" | "custom";
 
 const PRESETS = [
   { key: "namaz",     labelKey: "presetNamaz",     ids: [1, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114] },
@@ -37,6 +39,8 @@ export function SurahPickerScreen({ gameImg, difficultyOnly, onStart }: Props) {
   const memorized = useHifzStore((s) => s.memorized);
   const [difficulty, setDifficulty] = useState<Difficulty>("medium");
 
+  const studiedIds = useStudiedStore((s) => s.surahIds);
+
   const memorizedEntries = Object.entries(memorized)
     .filter(([, verses]) => verses.length > 0)
     .map(([id, verses]) => ({ surahId: Number(id), verses }))
@@ -44,8 +48,11 @@ export function SurahPickerScreen({ gameImg, difficultyOnly, onStart }: Props) {
 
   const hasHifz = memorizedEntries.length > 0;
 
+  const hasStudied = studiedIds.length > 0;
+
   const [mode, setMode] = useState<Mode>(() => {
     if (hasHifz) return "hifz";
+    if (hasStudied) return "studied";
     return savedIds.length > 0 ? "custom" : "all";
   });
   const [selected, setSelected] = useState<Set<number>>(new Set(savedIds));
@@ -89,6 +96,8 @@ export function SurahPickerScreen({ gameImg, difficultyOnly, onStart }: Props) {
         verseNums: e.verses,
       }));
       onStart(surahIds, verseFilter, difficulty);
+    } else if (mode === "studied") {
+      onStart(studiedIds, undefined, difficulty);
     } else {
       const ids = [...selected];
       saveIds(ids);
@@ -98,22 +107,22 @@ export function SurahPickerScreen({ gameImg, difficultyOnly, onStart }: Props) {
 
   const hifzTotalVerses = memorizedEntries.reduce((s, e) => s + e.verses.length, 0);
 
-  const MIN_CUSTOM_SURAHS = 10;
-
   const startButtonLabel = difficultyOnly
     ? t.surahPicker.startAll
     : mode === "all"
     ? t.surahPicker.startAll
     : mode === "hifz"
     ? t.surahPicker.testMyHifz.replace("{count}", String(hifzTotalVerses))
-    : selected.size >= MIN_CUSTOM_SURAHS
+    : mode === "studied"
+    ? t.surahPicker.startWithSurahs.replace("{count}", String(studiedIds.length))
+    : selected.size > 0
     ? t.surahPicker.startWithSurahs.replace("{count}", String(selected.size))
-    : t.surahPicker.minSurahHint.replace("{count}", String(MIN_CUSTOM_SURAHS));
+    : t.surahPicker.modeCustomHint;
 
-  const startDisabled = !difficultyOnly && mode === "custom" && selected.size < MIN_CUSTOM_SURAHS;
+  const startDisabled = !difficultyOnly && ((mode === "custom" && selected.size === 0) || (mode === "studied" && studiedIds.length === 0));
 
   return (
-    <div className="max-w-lg mx-auto px-4 py-6 pb-28">
+    <div className="max-w-3xl mx-auto px-4 py-6 pb-20">
       {/* Oyun görseli */}
       {gameImg && (
         <div className="flex justify-center mb-4">
@@ -127,7 +136,7 @@ export function SurahPickerScreen({ gameImg, difficultyOnly, onStart }: Props) {
 
       {/* Zorluk seçimi */}
       <div className="mb-5">
-        <div className="flex rounded-lg border border-[var(--color-border)] overflow-hidden">
+        <div className="flex rounded-lg border border-[var(--color-border)] overflow-hidden bg-[var(--color-surface)]">
           {(["easy", "medium", "hard", "hafiz"] as const).map((d) => {
             const active = difficulty === d;
             const label = t.gameScoring[d === "easy" ? "diffEasy" : d === "medium" ? "diffMedium" : d === "hard" ? "diffHard" : "diffHafiz"];
@@ -136,7 +145,7 @@ export function SurahPickerScreen({ gameImg, difficultyOnly, onStart }: Props) {
               <button
                 key={d}
                 onClick={() => setDifficulty(d)}
-                className={`flex-1 flex items-center justify-center gap-1.5 py-2 text-xs font-medium transition-all ${
+                className={`flex-1 flex items-center justify-center gap-1.5 py-2.5 text-xs font-medium transition-all ${
                   active
                     ? "bg-[var(--color-accent)]/10 text-[var(--color-accent)]"
                     : "text-[var(--color-text-secondary)] hover:bg-[var(--color-accent)]/5"
@@ -155,7 +164,7 @@ export function SurahPickerScreen({ gameImg, difficultyOnly, onStart }: Props) {
         {/* Tüm Kuran */}
         <button
           onClick={() => setMode("all")}
-          className={`w-full flex items-center gap-3 px-4 py-3.5 rounded border transition-all text-left ${
+          className={`w-full flex items-center gap-3 px-4 py-3.5 rounded-lg border transition-all text-left ${
             mode === "all"
               ? "border-[var(--color-accent)]/50 bg-[var(--color-accent)]/5"
               : "border-[var(--color-border)] bg-[var(--color-surface)] hover:border-[var(--color-accent)]/30"
@@ -169,61 +178,95 @@ export function SurahPickerScreen({ gameImg, difficultyOnly, onStart }: Props) {
         </button>
 
         {/* Ezberim */}
-        {hasHifz && (
-          <div className={`rounded border transition-all overflow-hidden ${
-            mode === "hifz"
+        <div className={`rounded-lg border transition-all overflow-hidden ${
+          mode === "hifz"
+            ? "border-[var(--color-accent)]/50 bg-[var(--color-accent)]/5"
+            : "border-[var(--color-border)] bg-[var(--color-surface)] hover:border-[var(--color-accent)]/30"
+        }`}>
+          <button
+            onClick={() => {
+              if (!hasHifz) return;
+              if (mode === "hifz") {
+                setHifzExpanded((v) => !v);
+              } else {
+                setMode("hifz");
+              }
+            }}
+            className={`w-full flex items-center gap-3 px-4 py-3.5 text-left ${!hasHifz ? "opacity-60" : ""}`}
+            disabled={!hasHifz}
+          >
+            <RadioDot active={mode === "hifz"} />
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium text-[var(--color-text-primary)]">{t.surahPicker.modeHifz}</p>
+              <p className="text-xs text-[var(--color-text-secondary)] mt-0.5">
+                {hasHifz
+                  ? `${memorizedEntries.length} ${t.surahPicker.modeHifzSurahs} · ${hifzTotalVerses} ${t.surahPicker.modeHifzVerses}`
+                  : t.surahPicker.noMemorized}
+              </p>
+            </div>
+            {hasHifz && mode === "hifz" && (
+              <svg className={`w-4 h-4 text-[var(--color-text-secondary)] transition-transform ${hifzExpanded ? "rotate-180" : ""}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+              </svg>
+            )}
+          </button>
+
+          {/* Hifz detay listesi */}
+          {mode === "hifz" && hasHifz && hifzExpanded && (
+            <div className="border-t border-[var(--color-border)]">
+              {memorizedEntries.map(({ surahId, verses }, i) => {
+                const surah = surahMap.get(surahId);
+                return (
+                  <div
+                    key={surahId}
+                    className={`flex items-center gap-2 px-4 py-1.5 ${i > 0 ? "border-t border-[var(--color-border)]/50" : ""}`}
+                  >
+                    <span className="text-[10px] text-[var(--color-text-secondary)] w-6 shrink-0 tabular-nums">{surahId}</span>
+                    <span className="text-xs text-[var(--color-text-primary)] flex-1 truncate">{surah?.nameSimple ?? `Sure ${surahId}`}</span>
+                    <span className="text-xs text-[var(--color-text-secondary)]" style={{ fontFamily: "var(--font-arabic)" }} dir="rtl">{surah?.nameArabic}</span>
+                    <span className="text-[10px] text-[var(--color-accent)] font-medium tabular-nums shrink-0 w-12 text-right">{verses.length} ayet</span>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          {/* Hifz yonetim linki */}
+          <div className="border-t border-[var(--color-border)] px-4 py-2">
+            <Link
+              to="/hifz"
+              className="text-xs text-[var(--color-accent)] hover:underline"
+            >
+              {t.surahPicker.manageHifz}
+            </Link>
+          </div>
+        </div>
+
+        {/* Çalıştıklarım */}
+        <button
+          onClick={() => { if (studiedIds.length > 0) setMode("studied"); }}
+          className={`w-full flex items-center gap-3 px-4 py-3.5 rounded-lg border transition-all text-left ${
+            mode === "studied"
               ? "border-[var(--color-accent)]/50 bg-[var(--color-accent)]/5"
               : "border-[var(--color-border)] bg-[var(--color-surface)] hover:border-[var(--color-accent)]/30"
-          }`}>
-            <button
-              onClick={() => {
-                if (mode === "hifz") {
-                  setHifzExpanded((v) => !v);
-                } else {
-                  setMode("hifz");
-                }
-              }}
-              className="w-full flex items-center gap-3 px-4 py-3.5 text-left"
-            >
-              <RadioDot active={mode === "hifz"} />
-              <div className="flex-1 min-w-0">
-                <p className="text-sm font-medium text-[var(--color-text-primary)]">{t.surahPicker.modeHifz}</p>
-                <p className="text-xs text-[var(--color-text-secondary)] mt-0.5">
-                  {memorizedEntries.length} {t.surahPicker.modeHifzSurahs} · {hifzTotalVerses} {t.surahPicker.modeHifzVerses}
-                </p>
-              </div>
-              {mode === "hifz" && (
-                <svg className={`w-4 h-4 text-[var(--color-text-secondary)] transition-transform ${hifzExpanded ? "rotate-180" : ""}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-                </svg>
-              )}
-            </button>
-
-            {mode === "hifz" && hifzExpanded && (
-              <div className="border-t border-[var(--color-border)]">
-                {memorizedEntries.map(({ surahId, verses }, i) => {
-                  const surah = surahMap.get(surahId);
-                  return (
-                    <div
-                      key={surahId}
-                      className={`flex items-center gap-2 px-4 py-1.5 ${i > 0 ? "border-t border-[var(--color-border)]/50" : ""}`}
-                    >
-                      <span className="text-[10px] text-[var(--color-text-secondary)] w-6 shrink-0 tabular-nums">{surahId}</span>
-                      <span className="text-xs text-[var(--color-text-primary)] flex-1 truncate">{surah?.nameSimple ?? `Sure ${surahId}`}</span>
-                      <span className="text-xs text-[var(--color-text-secondary)]" style={{ fontFamily: "var(--font-arabic)" }} dir="rtl">{surah?.nameArabic}</span>
-                      <span className="text-[10px] text-[var(--color-accent)] font-medium tabular-nums shrink-0 w-12 text-right">{verses.length} ayet</span>
-                    </div>
-                  );
-                })}
-              </div>
-            )}
+          } ${studiedIds.length === 0 ? "opacity-60" : ""}`}
+          disabled={studiedIds.length === 0}
+        >
+          <RadioDot active={mode === "studied"} />
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium text-[var(--color-text-primary)]">{t.surahPicker.presetWorked}</p>
+            <p className="text-xs text-[var(--color-text-secondary)] mt-0.5">
+              {studiedIds.length > 0
+                ? `${studiedIds.length} sure`
+                : t.profile.studiedEmpty}
+            </p>
           </div>
-        )}
+        </button>
 
         {/* Özel Seçim */}
         <button
           onClick={() => setMode("custom")}
-          className={`w-full flex items-center gap-3 px-4 py-3.5 rounded border transition-all text-left ${
+          className={`w-full flex items-center gap-3 px-4 py-3.5 rounded-lg border transition-all text-left ${
             mode === "custom"
               ? "border-[var(--color-accent)]/50 bg-[var(--color-accent)]/5"
               : "border-[var(--color-border)] bg-[var(--color-surface)] hover:border-[var(--color-accent)]/30"
@@ -234,9 +277,7 @@ export function SurahPickerScreen({ gameImg, difficultyOnly, onStart }: Props) {
             <p className="text-sm font-medium text-[var(--color-text-primary)]">{t.surahPicker.modeCustom}</p>
             <p className="text-xs text-[var(--color-text-secondary)] mt-0.5">
               {selected.size > 0
-                ? selected.size < MIN_CUSTOM_SURAHS
-                  ? t.surahPicker.selectedCount.replace("{count}", String(selected.size)) + ` (min ${MIN_CUSTOM_SURAHS})`
-                  : t.surahPicker.selectedCount.replace("{count}", String(selected.size))
+                ? t.surahPicker.selectedCount.replace("{count}", String(selected.size))
                 : t.surahPicker.modeCustomHint}
             </p>
           </div>
@@ -296,7 +337,7 @@ export function SurahPickerScreen({ gameImg, difficultyOnly, onStart }: Props) {
             </div>
 
             {/* Sure listesi */}
-            <div className="rounded border border-[var(--color-border)] overflow-hidden overflow-y-auto max-h-[50vh]">
+            <div className="rounded-lg border border-[var(--color-border)] overflow-hidden overflow-y-auto max-h-[50vh]">
               {isLoading ? (
                 <p className="text-center text-xs text-[var(--color-text-secondary)] py-6">{t.surahPicker.loading}</p>
               ) : (

--- a/apps/web/src/components/minimal-ui/AccountPage.tsx
+++ b/apps/web/src/components/minimal-ui/AccountPage.tsx
@@ -6,15 +6,17 @@ import { Link, useRouter } from "@tanstack/react-router";
 import { signOut } from "~/lib/auth-client";
 import { useBookmarksStore } from "~/stores/bookmarks.store";
 import { useReadingStore } from "~/stores/reading.store";
-import { useHifzStore, computeHifzStats } from "~/stores/hifz.store";
+import { useHifzStore, computeHifzStats, SURAH_VERSE_COUNTS } from "~/stores/hifz.store";
+import { useStudiedStore } from "~/stores/studied.store";
 import { useTranslation } from "~/hooks/useTranslation";
 import { useLocaleStore } from "~/stores/locale.store";
 import { useQuery } from "@tanstack/react-query";
 import { streakQueryOptions, activeHatimQueryOptions, completedHatimsQueryOptions } from "~/hooks/useHabitQuery";
 import { getMyScoreStats } from "~/lib/score-service";
 import { getSurahName } from "~/lib/surah-names-i18n";
+import { getSurahs } from "~/lib/quran-service";
 import { MuIcons } from "./icons";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 
 interface AccountPageProps {
   user: {
@@ -43,6 +45,16 @@ export function AccountPage({ user }: AccountPageProps) {
     staleTime: 60_000,
   });
 
+  const studiedIds = useStudiedStore((s) => s.surahIds);
+  const toggleStudied = useStudiedStore((s) => s.toggleSurah);
+
+  const { data: allSurahs = [] } = useQuery({
+    queryKey: ["quran", "surahs"],
+    queryFn: () => getSurahs(),
+    staleTime: Infinity,
+  });
+  const surahMap = useMemo(() => new Map(allSurahs.map((s) => [s.id, s])), [allSurahs]);
+
   const initial = user.name?.[0]?.toUpperCase() || "?";
   const hatimProgress = activeHatim ? Math.round((activeHatim.lastPage / 604) * 100) : 0;
   const totalGameScore = gameStats?.reduce((s, g) => s + g.bestScore, 0) ?? 0;
@@ -65,7 +77,7 @@ export function AccountPage({ user }: AccountPageProps) {
         )}
         <div>
           <h1 className="mu-display" style={{ fontSize: 36 }}>
-            {user.name || "Kullanici"}
+            {user.name || "Kullanıcı"}
           </h1>
           <p className="mu-muted" style={{ fontSize: 14, marginTop: 4 }}>{user.email}</p>
         </div>
@@ -96,7 +108,7 @@ export function AccountPage({ user }: AccountPageProps) {
         </div>
         <div className="mu-profile-stat">
           <span className="mu-astat-n">{streak?.todayPages ?? 0}</span>
-          <span className="mu-astat-l">Bugun</span>
+          <span className="mu-astat-l">Bugün</span>
         </div>
         <div className="mu-profile-stat">
           <span className="mu-astat-n">{hifzStats.totalVerses}</span>
@@ -124,41 +136,29 @@ export function AccountPage({ user }: AccountPageProps) {
             />
           </div>
           <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginTop: 8 }}>
-            <span className="mu-muted" style={{ fontSize: 12 }}>%{hatimProgress} tamamlandi</span>
+            <span className="mu-muted" style={{ fontSize: 12 }}>%{hatimProgress} tamamlandı</span>
             {completedHatims && completedHatims.length > 0 && (
               <span className="mu-muted" style={{ fontSize: 12 }}>
-                {completedHatims.length} hatim tamamlandi
+                {completedHatims.length} hatim tamamlandı
               </span>
             )}
           </div>
         </section>
       )}
 
-      {/* Hifz summary */}
-      {hifzStats.totalVerses > 0 && (
-        <section className="mu-profile-card">
-          <div className="mu-profile-card-header">
-            <span className="mu-profile-card-title">Hifz Durumu</span>
-            <span className="mu-muted" style={{ fontSize: 12, fontFamily: "var(--mu-ff-mono)" }}>
-              %{hifzStats.percentage.toFixed(1)}
-            </span>
-          </div>
-          <div className="mu-profile-progress-bar">
-            <div
-              className="mu-profile-progress-fill"
-              style={{ width: `${hifzStats.percentage}%` }}
-            />
-          </div>
-          <div style={{ display: "flex", gap: 16, marginTop: 8 }}>
-            <span className="mu-muted" style={{ fontSize: 12 }}>
-              {hifzStats.completeSurahs} sure tam
-            </span>
-            <span className="mu-muted" style={{ fontSize: 12 }}>
-              {hifzStats.activeSurahs} sure aktif
-            </span>
-          </div>
-        </section>
-      )}
+      {/* Ezberim (2/3) + Calistiklarim (1/3) */}
+      <div className="mu-profile-duo">
+        <MemorizedCard memorized={memorized} hifzStats={hifzStats} locale={locale} />
+
+        <StudiedCard
+          studiedIds={studiedIds}
+          surahMap={surahMap}
+          allSurahs={allSurahs}
+          locale={locale}
+          onToggle={toggleStudied}
+          t={t}
+        />
+      </div>
 
       {/* Game stats */}
       {totalGamePlays > 0 && (
@@ -180,39 +180,46 @@ export function AccountPage({ user }: AccountPageProps) {
             </div>
             <div className="mu-profile-stat">
               <span className="mu-astat-n" style={{ fontSize: 24 }}>{gameStats?.length ?? 0}</span>
-              <span className="mu-astat-l">Cesit</span>
+              <span className="mu-astat-l">Çeşit</span>
             </div>
           </div>
         </section>
       )}
 
-      {/* Navigation links */}
-      <nav className="mu-account-nav">
-        <Link to="/bookmarks" className="mu-account-link">
-          <span className="mu-account-link-icon">{MuIcons.bookmark}</span>
-          <span className="mu-account-link-text">
-            <strong>{t.hub.bookmarks}</strong>
-            <span>{t.hub.bookmarksDesc}</span>
-          </span>
-          {bookmarkCount > 0 && (
-            <span className="mu-account-link-badge">{bookmarkCount}</span>
+      {/* Navigation grid */}
+      <nav className="mu-account-grid">
+        <Link to="/hifz" className="mu-account-grid-item">
+          <span className="mu-account-grid-icon">{MuIcons.brain}</span>
+          <strong>{t.hub.hifz}</strong>
+          {hifzStats.totalVerses > 0 && (
+            <span className="mu-account-grid-badge">{hifzStats.totalVerses}</span>
           )}
         </Link>
 
-        <Link to="/notes" className="mu-account-link">
-          <span className="mu-account-link-icon">{MuIcons.note}</span>
-          <span className="mu-account-link-text">
-            <strong>{t.hub.notes}</strong>
-            <span>{t.hub.notesDesc}</span>
-          </span>
+        <Link to="/bookmarks" className="mu-account-grid-item">
+          <span className="mu-account-grid-icon">{MuIcons.bookmark}</span>
+          <strong>{t.hub.bookmarks}</strong>
+          {bookmarkCount > 0 && (
+            <span className="mu-account-grid-badge">{bookmarkCount}</span>
+          )}
         </Link>
 
-        <Link to="/premium" className="mu-account-link">
-          <span className="mu-account-link-icon">{MuIcons.settings}</span>
-          <span className="mu-account-link-text">
-            <strong>{t.hub.premium}</strong>
-            <span>{t.hub.premiumDesc}</span>
-          </span>
+        <Link to="/notes" className="mu-account-grid-item">
+          <span className="mu-account-grid-icon">{MuIcons.note}</span>
+          <strong>{t.hub.notes}</strong>
+        </Link>
+
+        <Link to="/games" className="mu-account-grid-item">
+          <span className="mu-account-grid-icon">{MuIcons.games}</span>
+          <strong>{t.hub.games}</strong>
+          {totalGamePlays > 0 && (
+            <span className="mu-account-grid-badge">{totalGamePlays}</span>
+          )}
+        </Link>
+
+        <Link to="/premium" className="mu-account-grid-item">
+          <span className="mu-account-grid-icon">{MuIcons.settings}</span>
+          <strong>{t.hub.premium}</strong>
         </Link>
       </nav>
 
@@ -229,5 +236,251 @@ export function AccountPage({ user }: AccountPageProps) {
         </button>
       </div>
     </div>
+  );
+}
+
+/* ── Ezberim karti ───────────────────────────────── */
+
+function MemorizedCard({
+  memorized,
+  hifzStats,
+  locale,
+}: {
+  memorized: Record<number, number[]>;
+  hifzStats: { totalVerses: number; completeSurahs: number; activeSurahs: number; percentage: number };
+  locale: string;
+}) {
+  const entries = useMemo(() => {
+    return Object.entries(memorized)
+      .filter(([, verses]) => verses && verses.length > 0)
+      .map(([id, verses]) => {
+        const surahId = Number(id);
+        const total = SURAH_VERSE_COUNTS[surahId] ?? 0;
+        const complete = verses.length === total;
+        return { surahId, count: verses.length, total, complete };
+      })
+      .sort((a, b) => a.surahId - b.surahId);
+  }, [memorized]);
+
+  return (
+    <section className="mu-profile-card" style={{ margin: 0 }}>
+      <div className="mu-profile-card-header">
+        <span className="mu-profile-card-title">Ezberim</span>
+        <Link to="/hifz" className="mu-muted" style={{ fontSize: 12, textDecoration: "none" }}>
+          Düzenle {MuIcons.arrowRight}
+        </Link>
+      </div>
+
+      {/* Progress bar */}
+      <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 10 }}>
+        <div className="mu-profile-progress-bar" style={{ flex: 1 }}>
+          <div
+            className="mu-profile-progress-fill"
+            style={{ width: `${hifzStats.percentage}%` }}
+          />
+        </div>
+        <span className="mu-muted" style={{ fontSize: 12, fontFamily: "var(--mu-ff-mono)", flexShrink: 0 }}>
+          %{hifzStats.percentage.toFixed(1)}
+        </span>
+      </div>
+
+      {/* Surah chips */}
+      {entries.length > 0 ? (
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+          {entries.map(({ surahId, count, total, complete }) => (
+            <span
+              key={surahId}
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 4,
+                fontSize: 12,
+                padding: "3px 8px",
+                borderRadius: 6,
+                background: complete ? "var(--mu-accent-soft)" : "var(--mu-bg-soft)",
+                color: complete ? "var(--mu-accent-ink)" : "var(--mu-ink-3)",
+              }}
+            >
+              {getSurahName(surahId, locale)}
+              {!complete && (
+                <span style={{ fontSize: 10, color: "var(--mu-muted)" }}>
+                  {count}/{total}
+                </span>
+              )}
+            </span>
+          ))}
+        </div>
+      ) : (
+        <p className="mu-muted" style={{ fontSize: 12 }}>
+          Henüz ezberlediğin sure yok
+        </p>
+      )}
+
+      {/* Stats footer */}
+      <div style={{ display: "flex", gap: 16, marginTop: 10 }}>
+        <span className="mu-muted" style={{ fontSize: 12 }}>
+          {hifzStats.completeSurahs} sure tam
+        </span>
+        <span className="mu-muted" style={{ fontSize: 12 }}>
+          {hifzStats.activeSurahs} sure aktif
+        </span>
+      </div>
+    </section>
+  );
+}
+
+/* ── Calistiklarim karti ──────────────────────────── */
+
+function StudiedCard({
+  studiedIds,
+  surahMap,
+  allSurahs,
+  locale,
+  onToggle,
+  t,
+}: {
+  studiedIds: number[];
+  surahMap: Map<number, { id: number; nameSimple: string; nameArabic: string; ayahCount: number }>;
+  allSurahs: { id: number; nameSimple: string; nameArabic: string; ayahCount: number }[];
+  locale: string;
+  onToggle: (id: number) => void;
+  t: any;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [search, setSearch] = useState("");
+
+  const filtered = search
+    ? allSurahs.filter(
+        (s) =>
+          s.nameSimple.toLowerCase().includes(search.toLowerCase()) ||
+          s.nameArabic.includes(search) ||
+          String(s.id).includes(search),
+      )
+    : allSurahs;
+
+  return (
+    <section className="mu-profile-card" style={{ margin: 0 }}>
+      <div className="mu-profile-card-header">
+        <span className="mu-profile-card-title">{t.profile.studied}</span>
+        <button
+          onClick={() => { setEditing((v) => !v); setSearch(""); }}
+          className="mu-muted"
+          style={{ fontSize: 12, background: "none", border: "none", cursor: "pointer" }}
+        >
+          {editing ? t.profile.studiedDone : t.profile.studiedEdit}
+        </button>
+      </div>
+
+      {/* Mevcut liste */}
+      {studiedIds.length > 0 ? (
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+          {studiedIds.map((id) => {
+            const name = getSurahName(id, locale) || surahMap.get(id)?.nameSimple || `${id}`;
+            return (
+              <span
+                key={id}
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: 4,
+                  fontSize: 12,
+                  padding: "3px 8px",
+                  borderRadius: 6,
+                  background: "var(--mu-bg-soft)",
+                  color: "var(--mu-ink-3)",
+                }}
+              >
+                {name}
+                {editing && (
+                  <button
+                    onClick={() => onToggle(id)}
+                    style={{
+                      background: "none",
+                      border: "none",
+                      cursor: "pointer",
+                      padding: 0,
+                      color: "var(--mu-muted)",
+                      fontSize: 14,
+                      lineHeight: 1,
+                    }}
+                  >
+                    x
+                  </button>
+                )}
+              </span>
+            );
+          })}
+        </div>
+      ) : !editing ? (
+        <p className="mu-muted" style={{ fontSize: 12 }}>
+          {t.profile.studiedEmpty}
+        </p>
+      ) : null}
+
+      {/* Duzenleme: sure ekleme */}
+      {editing && (
+        <div style={{ marginTop: 12 }}>
+          <input
+            type="text"
+            placeholder={t.surahPicker.searchPlaceholder}
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            style={{
+              width: "100%",
+              padding: "10px 14px",
+              fontSize: 14,
+              border: "1px solid var(--mu-line)",
+              borderRadius: 10,
+              background: "var(--mu-bg)",
+              color: "var(--mu-ink)",
+              outline: "none",
+              marginBottom: 8,
+            }}
+          />
+          <div style={{ maxHeight: 280, overflowY: "auto", borderRadius: 10, border: "1px solid var(--mu-line)" }}>
+            {filtered.map((s, i) => {
+              const active = studiedIds.includes(s.id);
+              return (
+                <button
+                  key={s.id}
+                  onClick={() => onToggle(s.id)}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 10,
+                    width: "100%",
+                    padding: "12px 14px",
+                    fontSize: 14,
+                    background: active ? "var(--mu-accent-soft)" : "transparent",
+                    border: "none",
+                    borderTop: i > 0 ? "1px solid var(--mu-line)" : "none",
+                    cursor: "pointer",
+                    color: active ? "var(--mu-accent-ink)" : "var(--mu-ink)",
+                    textAlign: "left",
+                  }}
+                >
+                  <span style={{
+                    width: 20, height: 20, borderRadius: 4, flexShrink: 0,
+                    display: "flex", alignItems: "center", justifyContent: "center",
+                    border: active ? "none" : "1.5px solid var(--mu-line-2)",
+                    background: active ? "var(--mu-accent)" : "transparent",
+                    color: "#fff", fontSize: 12,
+                  }}>
+                    {active && MuIcons.check}
+                  </span>
+                  <span style={{ width: 26, fontSize: 12, color: "var(--mu-muted)", fontFamily: "var(--mu-ff-mono)", flexShrink: 0 }}>
+                    {s.id}
+                  </span>
+                  <span style={{ flex: 1, fontWeight: active ? 500 : 400 }}>{getSurahName(s.id, locale) || s.nameSimple}</span>
+                  <span style={{ fontFamily: "var(--font-arabic, var(--mu-ff-ar))", fontSize: 14, color: "var(--mu-muted)" }} dir="rtl">
+                    {s.nameArabic}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </section>
   );
 }

--- a/apps/web/src/components/minimal-ui/icons.tsx
+++ b/apps/web/src/components/minimal-ui/icons.tsx
@@ -3,7 +3,7 @@
  * Each icon is a React element (not a component) for direct use in JSX.
  */
 
-import { MagnifyingGlass, House, Compass, BookOpen, BookmarkSimple, Play, Pause, CaretLeft, CaretRight, Sun, Moon, GearSix, X, ArrowRight, Trophy, User, Fire, Check, Copy, ShareNetwork, NotePencil, Lock, Microphone, Plus, Minus } from "@phosphor-icons/react";
+import { MagnifyingGlass, House, Compass, BookOpen, BookmarkSimple, Play, Pause, CaretLeft, CaretRight, Sun, Moon, GearSix, X, ArrowRight, Trophy, User, Fire, Check, Copy, ShareNetwork, NotePencil, Lock, Microphone, Plus, Minus, Brain, ClockCounterClockwise } from "@phosphor-icons/react";
 
 const w = 18;
 const p = { size: w, weight: "light" as const };
@@ -51,4 +51,6 @@ export const MuIcons = {
   mic: <Microphone {...p} />,
   plus: <Plus {...p} />,
   minus: <Minus {...p} />,
+  brain: <Brain {...p} />,
+  history: <ClockCounterClockwise {...p} />,
 } as const;

--- a/apps/web/src/locales/en.ts
+++ b/apps/web/src/locales/en.ts
@@ -256,6 +256,10 @@ export const en: Messages = {
       notStarted: "surahs not started",
       hint: "Tap a surah to open verse details. You can select individual verses, ranges, or all.",
     },
+    studied: "Recently Studied",
+    studiedEdit: "Edit",
+    studiedDone: "Done",
+    studiedEmpty: "Add the surahs you are working on for quick game selection",
   },
 
   bookmarks: {

--- a/apps/web/src/locales/tr.ts
+++ b/apps/web/src/locales/tr.ts
@@ -254,6 +254,10 @@ export const tr = {
       notStarted: "sure başlanmadı",
       hint: "Surelere dokunarak ayet detayını açın. Tek ayet, aralık veya tamamını seçebilirsiniz.",
     },
+    studied: "Çalıştıklarım",
+    studiedEdit: "Düzenle",
+    studiedDone: "Tamam",
+    studiedEmpty: "Çalıştığın sureleri ekle, oyunlarda hızlıca seç",
   },
 
   bookmarks: {
@@ -731,8 +735,8 @@ export const tr = {
     minSurahHint: "En az {count} sure seç",
     showDetails: "Detay",
     hideDetails: "Gizle",
-    manageHifz: "Ezberlerimi Duzenle",
-    presetWorked: "Calistiklarim",
+    manageHifz: "Ezberlerimi Düzenle",
+    presetWorked: "Çalıştıklarım",
   },
   gamesHub: {
     title: "Oyunlar",

--- a/apps/web/src/stores/studied.store.ts
+++ b/apps/web/src/stores/studied.store.ts
@@ -1,0 +1,51 @@
+/**
+ * Calistiklarim store'u -- kullanicinin aktif olarak calistigi sureler.
+ * Okuma gecmisi ve yer imlerinden otomatik beslenir,
+ * kullanici manuel olarak ekleyip cikarabilir.
+ */
+
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+interface StudiedState {
+  /** Manuel eklenen sure ID'leri */
+  surahIds: number[];
+}
+
+interface StudiedActions {
+  addSurah: (id: number) => void;
+  removeSurah: (id: number) => void;
+  toggleSurah: (id: number) => void;
+  setSurahs: (ids: number[]) => void;
+}
+
+export const useStudiedStore = create<StudiedState & StudiedActions>()(
+  persist(
+    (set) => ({
+      surahIds: [],
+
+      addSurah: (id) =>
+        set((s) => ({
+          surahIds: s.surahIds.includes(id)
+            ? s.surahIds
+            : [...s.surahIds, id].sort((a, b) => a - b),
+        })),
+
+      removeSurah: (id) =>
+        set((s) => ({
+          surahIds: s.surahIds.filter((sid) => sid !== id),
+        })),
+
+      toggleSurah: (id) =>
+        set((s) => ({
+          surahIds: s.surahIds.includes(id)
+            ? s.surahIds.filter((sid) => sid !== id)
+            : [...s.surahIds, id].sort((a, b) => a - b),
+        })),
+
+      setSurahs: (ids) =>
+        set({ surahIds: [...new Set(ids)].sort((a, b) => a - b) }),
+    }),
+    { name: "mahfuz-studied-surahs" },
+  ),
+);

--- a/apps/web/src/styles/minimal-ui.css
+++ b/apps/web/src/styles/minimal-ui.css
@@ -3746,6 +3746,69 @@ a:has(> .mu-roadmap-node):hover .mu-roadmap-node-content {
   color: var(--mu-accent);
 }
 
+/* ── Account grid (5-item navigation boxes) ──────────── */
+
+.mu-account-grid {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 8px;
+}
+
+@media (max-width: 480px) {
+  .mu-account-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.mu-account-grid-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 16px 8px;
+  border: 1px solid var(--mu-line);
+  border-radius: 12px;
+  text-decoration: none;
+  color: inherit;
+  transition: background 0.15s, border-color 0.15s;
+  text-align: center;
+  position: relative;
+}
+
+.mu-account-grid-item:hover {
+  background: var(--mu-bg-card);
+  border-color: var(--mu-accent);
+}
+
+.mu-account-grid-item strong {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--mu-ink);
+  line-height: 1.3;
+}
+
+.mu-account-grid-icon {
+  color: var(--mu-muted);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.mu-account-grid-icon svg {
+  width: 22px;
+  height: 22px;
+}
+
+.mu-account-grid-badge {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--mu-accent);
+  font-family: var(--mu-ff-mono);
+}
+
 /* ── Profile cards ──────────────────────────────────── */
 
 .mu-profile-continue {
@@ -3753,8 +3816,8 @@ a:has(> .mu-roadmap-node):hover .mu-roadmap-node-content {
   align-items: center;
   gap: 14px;
   padding: 16px 18px;
-  background: var(--mu-accent-soft);
-  border: 1px solid var(--mu-accent);
+  background: var(--mu-bg-card);
+  border: 1px solid var(--mu-line);
   border-radius: var(--mu-radius);
   text-decoration: none;
   color: inherit;
@@ -3763,7 +3826,8 @@ a:has(> .mu-roadmap-node):hover .mu-roadmap-node-content {
 }
 
 .mu-profile-continue:hover {
-  background: oklch(0.90 0.05 70);
+  background: var(--mu-bg-soft);
+  border-color: var(--mu-accent);
 }
 
 .mu-profile-continue-icon {
@@ -3815,6 +3879,19 @@ a:has(> .mu-roadmap-node):hover .mu-roadmap-node-content {
   display: flex;
   flex-direction: column;
   gap: 4px;
+}
+
+.mu-profile-duo {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+@media (max-width: 600px) {
+  .mu-profile-duo {
+    grid-template-columns: 1fr;
+  }
 }
 
 .mu-profile-card {


### PR DESCRIPTION
## Summary
- Add persistent `studied.store` for tracking actively worked-on surahs
- Redesign profile page: merged Hifz+Ezberim card (2/3) with progress bar + surah chips, Calistiklarim card (1/3) with inline edit, 5-column nav grid, fixed continue-reading card
- Game surah picker: Calistiklarim as standalone mode, removed min 10-surah restriction, consistent layout

## Test plan
- [ ] Profile page renders Ezberim card with progress bar and memorized surah chips
- [ ] Calistiklarim inline edit: add/remove surahs, search, mobile tap targets
- [ ] Game start: select Calistiklarim mode and start with any number of surahs
- [ ] Game start: custom selection works with fewer than 10 surahs
- [ ] Responsive: trio layout stacks on mobile (<600px)