### PR TITLE
Fix: explicit dist/client copy in Docker and add static asset diagnostics

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -19,7 +19,11 @@ RUN pnpm install --frozen-lockfile
 FROM deps AS build
 COPY . .
 ENV DEPLOY_TARGET=docker
-RUN pnpm turbo build --filter=@mahfuz/web
+RUN pnpm turbo build --filter=@mahfuz/web \
+    && echo "Build output:" \
+    && ls -la apps/web/dist/ \
+    && ls apps/web/dist/client/ | head -20 \
+    && echo "mushaf-pages: $(ls apps/web/dist/client/mushaf-pages/ | wc -l) files"
 
 # ── Stage 4: Runner ────────────────────────────────────
 FROM base AS runner
@@ -40,8 +44,9 @@ COPY --from=build /app/tooling/eslint/package.json tooling/eslint/
 # Install production dependencies only
 RUN pnpm install --frozen-lockfile --prod
 
-# Built app artifacts
-COPY --from=build /app/apps/web/dist apps/web/dist
+# Built app artifacts — client + server
+COPY --from=build /app/apps/web/dist/server apps/web/dist/server
+COPY --from=build /app/apps/web/dist/client apps/web/dist/client
 COPY --from=build /app/apps/web/drizzle apps/web/drizzle
 COPY --from=build /app/apps/web/drizzle.config.ts apps/web/drizzle.config.ts
 COPY --from=build /app/apps/web/server.mjs apps/web/server.mjs

--- a/apps/web/server.mjs
+++ b/apps/web/server.mjs
@@ -1,5 +1,5 @@
 import { createServer } from "node:http";
-import { readFile, stat } from "node:fs/promises";
+import { readFile, stat, readdir } from "node:fs/promises";
 import { join, extname } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -142,6 +142,17 @@ async function main() {
   }
 
   const clientDir = join(__dirname, "dist", "client");
+
+  // Startup diagnostics
+  try {
+    const clientStat = await stat(clientDir);
+    if (clientStat.isDirectory()) {
+      const entries = await readdir(clientDir);
+      console.log(`[mahfuz-core] Static dir: ${clientDir} (${entries.length} entries: ${entries.slice(0, 8).join(", ")}${entries.length > 8 ? "..." : ""})`);
+    }
+  } catch {
+    console.error(`[mahfuz-core] WARNING: Static dir not found: ${clientDir}`);
+  }
 
   const server = createServer(async (req, res) => {
     try {

--- a/apps/web/start.sh
+++ b/apps/web/start.sh
@@ -4,5 +4,15 @@ set -e
 echo "Running database migrations..."
 npx drizzle-kit migrate 2>&1 || echo "Warning: Migration failed, continuing with server startup"
 
+echo "Checking static assets..."
+if [ -d "dist/client" ]; then
+  echo "dist/client: $(ls dist/client/ | wc -l) entries"
+  echo "mushaf-pages: $(ls dist/client/mushaf-pages/ 2>/dev/null | wc -l) files"
+  echo "assets: $(ls dist/client/assets/ 2>/dev/null | wc -l) files"
+else
+  echo "WARNING: dist/client directory not found!"
+  ls -la dist/ 2>/dev/null || echo "dist/ directory also missing!"
+fi
+
 echo "Starting server..."
 exec node server.mjs


### PR DESCRIPTION
## Summary
- Split `COPY --from=build dist` into explicit `dist/server` + `dist/client` copies to ensure client assets are included in Docker image
- Add build verification step in Dockerfile (logs dist/client contents and mushaf-pages count)
- Add startup diagnostics in `start.sh` and `server.mjs` to log static asset availability
- Helps debug production 404s for CSS, fonts, and mushaf page images

## Test plan
- [ ] Deploy and check Dokploy logs for static asset diagnostics output
- [ ] Verify `/mushaf-pages/1.webp` returns 200 on production
- [ ] Verify `/assets/*.css` returns 200
- [ ] Navigate to `/page/1` and confirm no 404 errors in console