### PR TITLE
fix(i18n): always merge partial locales with Turkish fallback

### DIFF
--- a/apps/web/src/hooks/useTranslation.ts
+++ b/apps/web/src/hooks/useTranslation.ts
@@ -17,7 +17,8 @@ function resolveMessagesSync(locale: Locale): Messages | null {
 
   const config = getLocaleConfig(locale);
   if (Object.keys(config.messages).length > 0) {
-    const msgs = config.messages as Messages;
+    const loaded = config.messages;
+    const msgs = locale === "en" ? (loaded as Messages) : deepMerge(locale, tr, loaded);
     resolved.set(locale, msgs);
     return msgs;
   }
@@ -39,8 +40,7 @@ export function useTranslation() {
     let cancelled = false;
     loadLocaleMessages(locale).then((loaded) => {
       if (cancelled) return;
-      const config = getLocaleConfig(locale);
-      const msgs = Object.keys(loaded).length > 0 ? loaded : deepMerge(locale, tr, loaded);
+      const msgs = locale === "en" ? loaded : deepMerge(locale, tr, loaded);
       resolved.set(locale, msgs);
       setMessages(msgs);
     });


### PR DESCRIPTION
## Summary
- Non-Turkish, non-English locales export `PartialMessages`. The previous logic only invoked `deepMerge` when the loaded bundle was empty, so partial locales were returned as-is and any missing key crashed at runtime (e.g. `Cannot read properties of undefined (reading 'dayMon')` on NL because `nl.ts` has no `habit` namespace).
- Now `useTranslation` always merges with the Turkish base for every locale except `en` (which is the only complete non-TR locale), restoring the intended fallback.
- Fix applied in both `resolveMessagesSync` and the async `loadLocaleMessages` paths so a pre-warmed registry entry from `useSettingsSync`/`useSyncEngine` cannot bypass the merge either.

## Test plan
- [ ] Switch UI locale to Dutch and load a page that renders `WeeklyChart` (e.g. `/profile`); confirm no `dayMon` crash and labels fall back to Turkish.
- [ ] Repeat for `de`, `fr`, `es`, `ar` and spot-check missing keys fall back rather than crashing.
- [ ] English locale still renders without TR bleed-through.