### PR TITLE
fix(web): align submit button with form fields on auth page

### DIFF
--- a/apps/web/src/styles/minimal-ui.css
+++ b/apps/web/src/styles/minimal-ui.css
@@ -375,6 +375,7 @@
 
 .mu-btn {
   all: unset;
+  box-sizing: border-box;
   cursor: pointer;
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Özet

`/auth/login` sayfasındaki **"Giriş yap"** butonu, üstündeki form alanlarından (Google/Apple butonları, e-posta, parola) **44px daha geniş** çıkıyor; sağ kenarı dışarı taşarak buton kayık görünüyordu.

**Kök neden:** `.mu-btn` kuralı `all: unset` kullanıyor; bu da `box-sizing`'i tarayıcı varsayılanı olan `content-box`'a döndürüyor. Butona satır içi verilen `width: 100%` ile birlikte `12px 22px` padding genişliğin *üzerine* eklendiği için buton, kapsayıcısından her iki yandan toplam 44px (22 + 22) taşıyor. Inputlar `width` belirtmediğinden flex-column içinde `stretch` ile doğru genişlikte kalıyor; sorun yalnızca genişliği sabitlenmiş butonda görülüyor.

**Çözüm:** `.mu-btn`'e `box-sizing: border-box` eklendi. Böylece `width: 100%` padding'i de kapsıyor ve buton inputlarla tam hizalanıyor. Genişliği otomatik (width verilmemiş) butonlar bu değişiklikten etkilenmez.

## Test

Düzeltme canlı sayfada (`mahfuz.ilg.az/auth/login`) `getBoundingClientRect` ile ölçülerek doğrulandı:

| | Buton sağ kenarı − input sağ kenarı |
|---|---|
| **Önce** | `+44px` (taşma) |
| **Sonra** | `0px` (tam hizalı) |

Önce/sonra ekran görüntüleriyle görsel olarak da teyit edildi.

## Not

Değişiklik yalnızca CSS'tir (tek satır); yeni UI bileşeni, çeviri anahtarı veya cache anahtarı içermez — bu yüzden ilgili kontrol listesi maddeleri bu PR için geçerli değildir.
